### PR TITLE
Fix NullPointer in LoggingInterceptor

### DIFF
--- a/src/main/java/com/ks/management/configuration/LoggingInterceptor.java
+++ b/src/main/java/com/ks/management/configuration/LoggingInterceptor.java
@@ -17,7 +17,10 @@ public class LoggingInterceptor implements HandlerInterceptor {
         if(request.getRequestURI().equals("/health-check")){
             return true;
         }
-        final String username = request.getUserPrincipal().getName();
+        String username = "anonymous";
+        if(request.getUserPrincipal() != null){
+            username = request.getUserPrincipal().getName();
+        }
         final long startTime = System.currentTimeMillis();
         request.setAttribute("startTime", startTime);
         logger.info("Request from User: {} to path: {}", username, request.getRequestURI());


### PR DESCRIPTION
## Summary
- handle missing principal in LoggingInterceptor to avoid NPEs

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684465e849f08326bf5d77a24aeb269e